### PR TITLE
Fix uncaught init errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 
 node_js:
-  - "6"
   - "8"
   - "10"
   - "11"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/fastify/fastify-leveldb#readme",
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=8.6.0"
   },
   "dependencies": {
     "fastify-plugin": "^1.0.0",

--- a/test.js
+++ b/test.js
@@ -13,6 +13,19 @@ t.tearDown(() => {
   })
 })
 
+test('throw on database open error v2', t => {
+  t.plan(3)
+
+  const fastify = Fastify()
+  fastify
+    .register(level, { name: '/test' })
+    .ready(err => {
+      t.ok(err)
+      t.equal(err.message, 'IO error: /test/LOCK: No such file or directory')
+      t.pass('cannot write to /test, as expected')
+    })
+})
+
 test('level namespace should exist', t => {
   t.plan(3)
 


### PR DESCRIPTION
Without this patch, db initialization errors can go uncaught. I added a test to demonstrate, using "/test" location where it should be impossible to write.

I'm really not used to `tap` and I expect there's a much better way to write the test with `t.throws` or `t.rejects`. Any help on that end would be appreciated.

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
