### PR TITLE
Added custom path option

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,14 @@ fastify.register(require('fastify-leveldb'), {
 })
 ```
 
+By default the path where the db will be created is the name option, but you can also pass a custom path as well.
+```js
+fastify.register(
+  require('fastify-leveldb'),
+  { name: 'db', path: '.local' }
+)
+```
+
 ## Acknowledgements
 
 This project is kindly sponsored by:

--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ function levelPlugin (fastify, opts, next) {
     return next(new Error('Missing database name'))
   }
 
-  const { name } = opts
+  const { name, path } = opts
   opts.options = opts.options || {}
 
   if (!fastify.hasDecorator('level')) {
@@ -41,7 +41,7 @@ function levelPlugin (fastify, opts, next) {
     instance.level[name].close(done)
   })
 
-  fastify.level[name] = levelMore(name, opts.options, next)
+  fastify.level[name] = levelMore(path || name, opts.options, next)
 }
 
 module.exports = fp(levelPlugin, {


### PR DESCRIPTION
With this option is possible to choose a custom path that is different from the db name.

```js
fastify.register(
  require('fastify-leveldb'),
  { name: 'db', path: '.local' }
)
```

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
