### PR TITLE
Prep for fastify@5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   test:
-    uses: fastify/workflows/.github/workflows/plugins-ci.yml@v3
+    uses: fastify/workflows/.github/workflows/plugins-ci.yml@v4.2.1
     with:
       license-check: true
       lint: true

--- a/package.json
+++ b/package.json
@@ -29,14 +29,14 @@
   "homepage": "https://github.com/fastify/fastify-leveldb#readme",
   "dependencies": {
     "encoding-down": "^7.0.0",
-    "fastify-plugin": "^4.0.0",
+    "fastify-plugin": "^5.0.0-pre.fv5.1",
     "leveldown": "^6.0.0",
     "levelup": "^5.0.0"
   },
   "devDependencies": {
-    "@fastify/pre-commit": "^2.0.2",
+    "@fastify/pre-commit": "^2.1.0",
     "@types/levelup": "^5.1.0",
-    "fastify": "^4.0.0-rc.3",
+    "fastify": "^5.0.0-alpha.3",
     "memdown": "^6.0.0",
     "rimraf": "^5.0.0",
     "standard": "^17.0.0",


### PR DESCRIPTION
This one didn't get a `next` prep but is needed for `@fastify/auth`. I am not going to take the time to update `tap`. It's a dev dependency and can be updated later.